### PR TITLE
Fix Source Install Disk Detection in get_disk_list 

### DIFF
--- a/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
+++ b/dracut/modules.d/90kiwi-dump/kiwi-dump-image.sh
@@ -49,6 +49,8 @@ function get_disk_list {
     local kiwi_oem_maxdisk
     local blk_opts="-p -n -r -o NAME,SIZE,TYPE"
     local message
+    local blk_opts_plus_label="${blk_opts},LABEL"
+    local kiwi_install_disk_part=$(lsblk "${blk_opts_plus_label}" | tr ' ' ":" | grep "${kiwi_install_volid}" | cut -f1 -d:)
     if [ -n "${kiwi_devicepersistency}" ];then
         disk_id=${kiwi_devicepersistency}
     fi
@@ -79,9 +81,7 @@ function get_disk_list {
         eval lsblk "${blk_opts}" | grep -E "disk|raid" | tr ' ' ":"
     );do
         disk_device="$(echo "${disk_meta}" | cut -f1 -d:)"
-        if [ "$(blkid "${disk_device}" -s LABEL -o value)" = \
-            "${kiwi_install_volid}" ]
-        then
+        if [[ "${kiwi_install_disk_part}" == "${disk_device}"* ]]; then
             # ignore install source device
             continue
         fi


### PR DESCRIPTION
- Account for Disk Type variation between Install Media and Target Media

The original check doesn't always work because PARTITIONS get labels, NOT disks. If you install with a Flash Drive and deploy to a machine with an NVMe drive, the Flash Drive is listed first because SCSIs are shown first by lsblk. When we run 'blkid "[Install Flash Drive Disk]" -s LABEL -o value' in this scenario, we get nothing returned so this conditional evaluates incorrectly. We should get the ${kiwi_install_volid} Partition Block Name, and search for whether ${disk_device} is contained within it as the Disk Device that corresponds to the Install Partition.

Ex: 
    Flash Drive ${disk_device} /dev/sda is a substring of ${kiwi_install_disk_part} /dev/sda1, which has a LABEL/${kiwi_install_volid} of INSTALL. Therefore, we should ignore this ${disk_device}

Because Disk Device + Partition Block Names are standardized and additive for NVMes, SCSIs, and every other Type, this method of detection of the Install Device will work under every scenario. The Disk Name is always the first part of the Partition Name.

Fixes # .

Changes proposed in this pull request:
*
*
